### PR TITLE
Added Null check for DeployTest

### DIFF
--- a/src/main/java/com/ca/devtest/jenkins/plugin/buildstep/DevTestDeployTest.java
+++ b/src/main/java/com/ca/devtest/jenkins/plugin/buildstep/DevTestDeployTest.java
@@ -376,6 +376,7 @@ public class DevTestDeployTest extends DefaultBuildStep {
 		if (jsonTree.isJsonObject()) {
 			JsonObject jsonObject = jsonTree.getAsJsonObject();
 			JsonElement testStatus = jsonObject.get("testStatus");
+			if(testStatus !=null)
 			return testStatus.getAsString();
 		}
 		return "";


### PR DESCRIPTION
Hello
           Please kindly review the change in context of Rally defect DE449105 where customer has complained that Jenkins job to DeployTest Failed even though the test continued to run in Portal and completed succesfully.

regards
Sankar